### PR TITLE
Add metaprogramming for list of commands

### DIFF
--- a/lib/wicked_game.rb
+++ b/lib/wicked_game.rb
@@ -2,7 +2,7 @@ require "discordrb"
 require_relative "wicked_pool"
 
 class WickedGame
-  COMMANDS = %i[roll show list]
+  COMMANDS = %i[roll show list clear]
 
   def initialize
     self.player_pools = {}
@@ -22,7 +22,7 @@ class WickedGame
   end
 
   def list(event:, args:)
-    player_pools.map { |pool, player| "#{player} rolled #{pool}" }.join("\n")
+    player_pools.map { |player, pool| "#{player} rolled #{pool}" }.join("\n")
   end
 
   def clear(event:, args:)

--- a/wicked.rb
+++ b/wicked.rb
@@ -1,23 +1,24 @@
 # frozen_string_literal: true
-require 'discordrb'
-require 'json'
-require_relative 'lib/wicked_game'
 
-info = JSON.parse(File.read('./info.json'))
+require "discordrb"
+require "json"
+require_relative "lib/wicked_game"
 
-bot = Discordrb::Commands::CommandBot.new token: info["token"], client_id: info["client_id"], prefix: '/'
+info = JSON.parse(File.read("./info.json"))
+
+bot = Discordrb::Commands::CommandBot.new token: info["token"], client_id: info["client_id"], prefix: "/"
 
 puts "This bot's invite URL is #{bot.invite_url}."
-puts 'Click on it to invite it to your server.'
+puts "Click on it to invite it to your server."
 
-game = WickedGame.new()
+game = WickedGame.new
 
-bot.command :roll do |event, *args|
-  game.roll(args: args, event: event)
+WickedGame::COMMANDS.each do |command|
+  bot.command command do |event, *args|
+    game.send(command, {args: args, event: event})
+  end
 end
 
 at_exit { bot.stop }
 
-# This method call has to be put at the end of your script, it is what makes the bot actually connect to Discord. If you
-# leave it out (try it!) the script will simply stop and the bot will not appear online.
 bot.run


### PR DESCRIPTION
The process of adding commands was going to start getting tedious.
Having a separate block for each command defining what to call in
`WickedGame` for this command was going to be either very repetitive
since each block would be identical, or it would be introducing code
that would be hard to have under test.

Instead, this model has `WickedGame` share a list of commands that it
can handle, and `wicked.rb` just passes the event invocation details to
`WickedGame` for all commands in that list.  With this change, we can
add new methods to `WickedGame` and just add them into `COMMANDS`, and
they will be automatically stitched into the list of commands that
Discordrb is listening for.