### PR TITLE
Add advantage dice modification

### DIFF
--- a/lib/wicked_game.rb
+++ b/lib/wicked_game.rb
@@ -2,7 +2,7 @@ require "discordrb"
 require_relative "wicked_pool"
 
 class WickedGame
-  COMMANDS = %i[roll show list clear roll_for show_for clear_for]
+  COMMANDS = %i[roll show list clear roll_for show_for clear_for advantage]
 
   def initialize
     self.player_pools = {}
@@ -45,6 +45,15 @@ class WickedGame
 
   def clear_for(event:, args:, randomizer: Random)
     clear_for_player(player: extract_player(args))
+  end
+
+  def advantage(event:, args:)
+    player = if args.size == 1
+      event.author.nickname
+    else
+      args[0...-1].join(" ")
+    end
+    "#{player}: #{player_pools[player].adjust_advantage(args.last)}"
   end
 
   # standard:enable Lint/UnusedMethodArgument

--- a/lib/wicked_pool.rb
+++ b/lib/wicked_pool.rb
@@ -22,8 +22,34 @@ class WickedPool
     dice.map(&:to_s).join(", ")
   end
 
+  def adjust_advantage(adjustment)
+    if adjustment == "+"
+      dice.push(WickedDie.create(die: "A"))
+      "Added an advantage die"
+    else
+      remove_advantage
+    end
+  end
+
   private
 
   attr_accessor :randomizer
   attr_writer :dice, :result
+
+  def remove_advantage
+    if has_advantage?
+      dice.delete_at(first_advantage_index)
+      "Removed an advantage die"
+    else
+      "No advantage die to remove"
+    end
+  end
+
+  def has_advantage?
+    dice.any? { |die| die.advantage? }
+  end
+
+  def first_advantage_index
+    dice.find_index { |die| die.advantage? }
+  end
 end

--- a/spec/wicked_game_spec.rb
+++ b/spec/wicked_game_spec.rb
@@ -51,8 +51,50 @@ RSpec.describe WickedGame do
       game.clear(args: [], event: event)
       expect(game.list(args: [], event: event)).not_to include("TestUser")
     end
+  end
 
-    it "can add or remove advantage dice to the roll"
+  describe "#advantage" do
+    it "can add advantage dice to the current player's roll" do
+      args = %w[d10 d8]
+      game.roll(args: args, event: event)
+      expect(game.advantage(args: ["+"], event: event)).to eq("TestUser: Added an advantage die")
+      expect(game.show(args: [], event: event)).to match(/TestUser's current pool is: d10: \d+, d8: \d, advantage: unrolled/)
+    end
+
+    it "can remove advantage dice from the current player's roll" do
+      args = %w[d10 d8 A]
+      game.roll(args: args, event: event)
+      expect(game.advantage(args: ["-"], event: event)).to eq("TestUser: Removed an advantage die")
+      expect(game.show(args: [], event: event)).to match(/TestUser's current pool is: d10: \d+, d8: \d/)
+    end
+
+    it "can add advantage dice to a given character's roll" do
+      args = %w[Some other Character d10 d8]
+      game.roll_for(args: args, event: event)
+      expect(game.advantage(args: %w[Some other Character +], event: event)).to eq("Some other Character: Added an advantage die")
+      expect(game.show_for(args: %w[Some other Character], event: event)).to match(/Some other Character's current pool is: d10: \d+, d8: \d, advantage: unrolled/)
+    end
+
+    it "can remove advantage dice from a given character's roll" do
+      args = %w[Some other Character d10 d8 A]
+      game.roll_for(args: args, event: event)
+      expect(game.advantage(args: %w[Some other Character -], event: event)).to eq("Some other Character: Removed an advantage die")
+      expect(game.show_for(args: %w[Some other Character], event: event)).to match(/Some other Character's current pool is: d10: \d+, d8: \d/)
+    end
+
+    it "can add a second advantage die" do
+      args = %w[d10 d8 A]
+      game.roll(args: args, event: event)
+      expect(game.advantage(args: ["+"], event: event)).to eq("TestUser: Added an advantage die")
+      expect(game.show(args: [], event: event)).to match(/TestUser's current pool is: d10: \d+, d8: \d, advantage: \d, advantage: unrolled/)
+    end
+
+    it "can remove one advantage die without removing the second if they have two" do
+      args = %w[d10 d8 A A]
+      game.roll(args: args, event: event)
+      expect(game.advantage(args: ["-"], event: event)).to eq("TestUser: Removed an advantage die")
+      expect(game.show(args: [], event: event)).to match(/TestUser's current pool is: d10: \d+, d8: \d, advantage: \d/)
+    end
   end
 
   describe "#roll_for" do

--- a/spec/wicked_pool_spec.rb
+++ b/spec/wicked_pool_spec.rb
@@ -41,5 +41,41 @@ RSpec.describe WickedPool do
         end
       end
     end
+
+    describe "#adjust_advantage" do
+      context "with just two dice" do
+        it "adds an advantage to the die pool" do
+          args = %w[d12 d8]
+          subject = described_class.new(dice: args)
+          expect(subject.adjust_advantage("+")).to eq("Added an advantage die")
+          expect(subject.dice_list).to eq("d12: unrolled, d8: unrolled, advantage: unrolled")
+        end
+      end
+
+      context "with an advantage die" do
+        it "removes an advantage from the die pool" do
+          args = %w[d12 d8 A]
+          subject = described_class.new(dice: args)
+          expect(subject.adjust_advantage("-")).to eq("Removed an advantage die")
+          expect(subject.dice_list).to eq("d12: unrolled, d8: unrolled")
+        end
+
+        it "adds a second advantage to the die pool" do
+          args = %w[d12 d8 A]
+          subject = described_class.new(dice: args)
+          expect(subject.adjust_advantage("+")).to eq("Added an advantage die")
+          expect(subject.dice_list).to eq("d12: unrolled, d8: unrolled, advantage: unrolled, advantage: unrolled")
+        end
+      end
+
+      context "with two advantage dice" do
+        it "removes an advantage from the die pool" do
+          args = %w[d12 d8 A A]
+          subject = described_class.new(dice: args)
+          expect(subject.adjust_advantage("-")).to eq("Removed an advantage die")
+          expect(subject.dice_list).to eq("d12: unrolled, d8: unrolled, advantage: unrolled")
+        end
+      end
+    end
   end
 end

--- a/spec/wicked_result_spec.rb
+++ b/spec/wicked_result_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe WickedResult do
   describe "#standard_dice" do
     let(:standard_dice) do
       [WickedDie.create(die: "d8"),
-       WickedDie.create(die: "d12")]
+        WickedDie.create(die: "d12")]
     end
 
     let(:dice) { standard_dice.clone }


### PR DESCRIPTION
It is now possible to use `/advantage` to adjust advantage dice in a
pool.  Specifically, you can now say `/advantage +` to add and advantage
die, or `/advantage -` to remove one from your pool.  You can also use
`/advantage Some Character Name +` to add an advantage die to Some
Character Name's pool, and similar for `-`.

Note that `/advantage` is using a pattern I hope to extend to the other
`/` commands which have regular versions and `_for` versions where you
specify the character name.  I want to change them so that they all will
check to see if there is a character name.  But that is a future
enhancement.