### PR TITLE
Fix a list bug with unrolled advantage dice

### DIFF
--- a/lib/wicked_die.rb
+++ b/lib/wicked_die.rb
@@ -8,7 +8,7 @@ class WickedDie
     end
   end
 
-  attr_reader :sides, :advantage, :result
+  attr_reader :sides, :advantage, :value
 
   def <=>(other)
     if advantage?
@@ -24,11 +24,11 @@ class WickedDie
     self.sides = die[1..].to_i
     self.advantage = false
     self.randomizer = randomizer
-    self.result = "unrolled"
+    self.value = 0
   end
 
   def roll
-    self.result = randomizer.rand(1..sides)
+    self.value = randomizer.rand(1..sides)
   end
 
   def to_s
@@ -39,10 +39,14 @@ class WickedDie
     advantage
   end
 
+  def result
+    value == 0 ? "unrolled" : value
+  end
+
   private
 
   attr_accessor :randomizer
-  attr_writer :sides, :advantage, :result
+  attr_writer :sides, :advantage, :value
 end
 
 class AdvantageDie < WickedDie
@@ -50,7 +54,7 @@ class AdvantageDie < WickedDie
     self.advantage = true
     self.randomizer = randomizer
     self.sides = 6
-    self.result = "unrolled"
+    self.value = 0
   end
 
   def to_s

--- a/lib/wicked_result.rb
+++ b/lib/wicked_result.rb
@@ -23,11 +23,11 @@ class WickedResult
   end
 
   def unmodified_values
-    standard_dice.map(&:result).sort.reverse
+    standard_dice.map(&:value).sort.reverse
   end
 
   def advantage_sum
-    advantage_dice.map(&:result).sum
+    advantage_dice.map(&:value).sum
   end
 
   def to_s

--- a/spec/wicked_die_spec.rb
+++ b/spec/wicked_die_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe WickedDie do
           end
         end
 
+        describe "#value" do
+          it "returns 0 when it hasn't been rolled yet" do
+            expect(subject.value).to eq(0)
+          end
+
+          it "uses a randomizer to return the value if it is rolled" do
+            subject.roll
+            expect(subject.value).to eq(random_result)
+          end
+        end
+
         describe "#result" do
           it "returns unrolled when it hasn't been rolled yet" do
             expect(subject.result).to eq("unrolled")
@@ -64,6 +75,17 @@ RSpec.describe WickedDie do
 
         it "has the advantage flag set" do
           expect(subject.advantage).to be_truthy
+        end
+      end
+
+      describe ".value" do
+        it "returns 0 when it hasn't been rolled yet" do
+          expect(subject.value).to eq(0)
+        end
+
+        it "uses a randomizer to return the value if it is rolled" do
+          subject.roll
+          expect(subject.value).to eq(random_result)
         end
       end
 

--- a/spec/wicked_game_spec.rb
+++ b/spec/wicked_game_spec.rb
@@ -19,6 +19,24 @@ RSpec.describe WickedGame do
     end
   end
 
+  describe "#list" do
+    it "correctly displays pools with unrolled dice" do
+      randomizer = class_double(Random)
+      allow(randomizer).to receive(:rand).with(1..12).and_return(7)
+      allow(randomizer).to receive(:rand).with(1..4).and_return(2)
+
+      roll_args = %w[d12 d4]
+      game.roll(args: roll_args, event: event, randomizer: randomizer)
+
+      adv_args = %w[+]
+      game.advantage(event: event, args: adv_args)
+
+      subject = game.list(event: event, args: [])
+
+      expect(subject).to eq("TestUser rolled 7, 2 (d12: 7, d4: 2, advantage: unrolled)")
+    end
+  end
+
   describe ".roll" do
     it "rolls the dice given for the player" do
       randomizer = class_double(Random)

--- a/spec/wicked_pool_spec.rb
+++ b/spec/wicked_pool_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe WickedPool do
       end
     end
 
+    describe "#to_s" do
+      context "with an unrolled advantage die" do
+        it "shows the unrolled die, but doesn't roll it" do
+          args = %w[d12 d8]
+          subject = described_class.new(dice: args)
+          subject.roll
+          subject.adjust_advantage("+")
+          expect(subject.to_s).to match(/\d+, \d+ \(d12: \d+, d8: \d+, advantage: unrolled\)/)
+        end
+      end
+    end
+
     describe "#dice_list" do
       context "with just two dice" do
         it "just shows the dice in the pool, not the result" do

--- a/spec/wicked_result_spec.rb
+++ b/spec/wicked_result_spec.rb
@@ -73,6 +73,31 @@ RSpec.describe WickedResult do
         expect(subject.result).to eq("15, 3 (d12: 10, d8: 3, advantage: 5)")
       end
     end
+
+    context "when given an unrolled advantage dite" do
+      let(:randomizer1) { class_double(Random) }
+      let(:randomizer2) { class_double(Random) }
+      let(:randomizerA) { class_double(Random) }
+
+      before do
+        allow(randomizer1).to receive(:rand).and_return(3)
+        allow(randomizer2).to receive(:rand).and_return(10)
+        allow(randomizerA).to receive(:rand).and_return(5)
+      end
+
+      let(:dice) do
+        [WickedDie.create(die: "d8", randomizer: randomizer1),
+         WickedDie.create(die: "d12", randomizer: randomizer2)]
+      end
+
+      let(:advantage_die) { WickedDie.create(die: "A", randomizer: randomizerA) }
+
+      it "should show the advantage die as unrolled" do
+        subject = described_class.new(dice)
+        dice.push(advantage_die)
+        expect(subject.result).to eq("10, 3 (d12: 10, d8: 3, advantage: unrolled)")
+      end
+    end
   end
 
   describe "#advantage_dice" do


### PR DESCRIPTION
When a player had added an advantage die, but had not rolled it yet, the
logic for displaying the list of dice would break as it tried to add the
advantage dice together, but the dice had the results of "unrolled".

The fix was to break apart the concept of "result" and "value".  The
result of a die is "unrolled" - the string representation, basically.
The value of a die is 0 if it hasn't been rolled.

By separating this out, we can identify when we want the values (when we
are summing up the total result) and when we want the result (when we
are displaying the current pool state.

Most of the work here was adding the tests, which are possibly
excessive, but it was helpful to step down through the code to identify
where the failure was happening, so I'm keeping all of the tests for
now.