### PR TITLE
Remove `_for` methods

### DIFF
--- a/lib/wicked_game.rb
+++ b/lib/wicked_game.rb
@@ -2,49 +2,32 @@ require "discordrb"
 require_relative "wicked_pool"
 
 class WickedGame
-  COMMANDS = %i[roll show list clear roll_for show_for clear_for adv]
+  COMMANDS = %i[roll show list clear adv]
 
   def initialize
     self.player_pools = {}
   end
 
   def roll(event:, args:, randomizer: Random)
-    player = event.author.nickname
-    roll_for_player(player: player, dice: args, randomizer: randomizer)
+    player = extract_player(args, event)
+    roll_for_player(player: player, dice: extract_dice(args), randomizer: randomizer)
+  end
+
+  def show(event:, args:)
+    player = extract_player(args, event)
+    show_for_player(player: player)
   end
 
   # standard:disable Lint/UnusedMethodArgument for the following, which
   # don't need the args(yet), but will still be passed the args.
-  def show(event:, args:)
-    player = event.author.nickname
-    show_for_player(player: player)
-  end
-
   def list(event:, args:)
     player_pools.map { |player, pool| "#{player} rolled #{pool}" }.join("\n")
   end
+  # standard:enable Lint/UnusedMethodArgument
 
   def clear(event:, args:)
-    player = event.author.nickname
+    player = extract_player(args, event)
     clear_for_player(player: player)
-  end
-
-  def roll_for(event:, args:, randomizer: Random)
-    player = extract_player(args)
-    dice = if first_die_index(args) != 0
-      extract_dice(args)
-    else
-      []
-    end
-    roll_for_player(player: player, dice: dice, randomizer: randomizer)
-  end
-
-  def show_for(event:, args:, randomizer: Random)
-    show_for_player(player: extract_player(args))
-  end
-
-  def clear_for(event:, args:, randomizer: Random)
-    clear_for_player(player: extract_player(args))
   end
 
   def adv(event:, args:)
@@ -56,16 +39,22 @@ class WickedGame
     "#{player}: #{player_pools[player].adjust_advantage(args.last)}"
   end
 
-  # standard:enable Lint/UnusedMethodArgument
-
   private
 
   DIE_REGEX = /d\d{1,2}/
 
   attr_accessor :player_pools
 
-  def extract_player(args)
-    args[0..first_die_index(args) - 1].join(" ")
+  def extract_player(args, event)
+    player = passed_player(args)
+    if player == ""
+      player = event.author.nickname
+    end
+    player
+  end
+
+  def passed_player(args)
+    args.take(first_die_index(args)).join(" ")
   end
 
   def extract_dice(args)
@@ -73,7 +62,7 @@ class WickedGame
   end
 
   def first_die_index(array)
-    array.index { |element| DIE_REGEX.match?(element) } || 0
+    array.index { |element| DIE_REGEX.match?(element) } || array.length
   end
 
   def roll_for_player(player:, dice:, randomizer: Random)


### PR DESCRIPTION
It was hard to remember to type _for all of the time when working as the
GM.  Instead, it makes sense to just have the system figure out if
you've passed a player name.  If there is a player name, then use that
name.  If there isn't, then use the default name passed by the event.

This cleaned up the code a good bit, really.  I like this refactoring -
it removes a lot of duplicate code.