### PR TITLE
Fix crashes caused by bad input

### DIFF
--- a/lib/wicked_game.rb
+++ b/lib/wicked_game.rb
@@ -77,8 +77,10 @@ class WickedGame
   end
 
   def roll_for_player(player:, dice:, randomizer: Random)
-    if !player_pools.has_key?(player) || !dice.empty?
+    if !dice.empty?
       player_pools[player] = WickedPool.new(dice: dice, randomizer: randomizer)
+    elsif !player_pools.has_key?(player)
+      return "Character #{player} has no current dice pool, and no dice were provided"
     end
     "#{player} rolled #{player_pools[player].roll}"
   end

--- a/spec/features_spec.rb
+++ b/spec/features_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe "Feature Tests" do
       subject = game.roll(args: [], event: event)
       expect(subject).to match(/TestUser rolled \d+, \d+ \(d10: \d+, d8: \d, advantage: \d\)/)
     end
+
+    it "handles bad input" do
+      args = %w[d-1]
+      subject = game.roll(args: args, event: event)
+      expect(subject).to eq("Character d-1 has no current dice pool, and no dice were provided")
+    end
   end
 
   describe "Started and ending conflict" do


### PR DESCRIPTION
The system was interpreting most bad input as if it was a character,
with no dice.  It was then throwing an error because, if there is a
character name provided without any dice, it assumes the character
already has a dice pool that should be re-rolled.

However, in this case, there is no dice pool.  The solution is to add a
guard clause that will ensure that the input is what we are expecting,
and to give an error if it doesn't match.