### PR TITLE
Partial name lookup

### DIFF
--- a/lib/wicked_game.rb
+++ b/lib/wicked_game.rb
@@ -10,12 +10,14 @@ class WickedGame
 
   def roll(event:, args:, randomizer: Random)
     player = extract_player(args, event)
-    roll_for_player(player: player, dice: extract_dice(args), randomizer: randomizer)
+    return "Error- two matching characters: #{player.join(", ")}" unless player.length == 1
+    roll_for_player(player: player.first, dice: extract_dice(args), randomizer: randomizer)
   end
 
   def show(event:, args:)
     player = extract_player(args, event)
-    show_for_player(player: player)
+    return "Error- two matching characters: #{player.join(", ")}" unless player.length == 1
+    show_for_player(player: player.first)
   end
 
   # standard:disable Lint/UnusedMethodArgument for the following, which
@@ -45,7 +47,8 @@ class WickedGame
 
   def clear(event:, args:)
     player = extract_player(args, event)
-    clear_for_player(player: player)
+    return "Error- two matching characters: #{player.join(", ")}" unless player.length == 1
+    clear_for_player(player: player.first)
   end
 
   def adv(event:, args:)
@@ -66,13 +69,22 @@ class WickedGame
   def extract_player(args, event)
     player = passed_player(args)
     if player == ""
-      player = event.author.nickname
+      [event.author.nickname]
+    else
+      player_lookup(player)
     end
-    player
   end
 
   def passed_player(args)
     args.take(first_die_index(args)).join(" ")
+  end
+
+  def player_lookup(player)
+    if player_pools.keys.find { |key| key.start_with?(player) }
+      player_pools.keys.filter { |key| key.start_with?(player) }
+    else
+      [player]
+    end
   end
 
   def extract_dice(args)

--- a/spec/wicked_game_spec.rb
+++ b/spec/wicked_game_spec.rb
@@ -122,6 +122,28 @@ RSpec.describe WickedGame do
       expect(subject).to include("advantage")
     end
 
+    it "can look up a player by a shortend version of their name" do
+      dice_args = %w[Other Character with de Long Name d10 d8 A]
+      game.roll(args: dice_args, event: event)
+      name_args = %w[Other]
+      subject = game.roll(args: name_args, event: event)
+
+      expect(subject).to start_with("Other Character with de Long Name rolled")
+      expect(subject).to include("d10")
+      expect(subject).to include("d8")
+      expect(subject).to include("advantage")
+    end
+
+    it "will fail to look up a player when there is more than one possibility" do
+      first_player_args = %w[player one d10 d8 A]
+      game.roll(args: first_player_args, event: event)
+      second_player_args = %w[player two d10 d8 A]
+      game.roll(args: second_player_args, event: event)
+      name_args = %w[play]
+      subject = game.roll(args: name_args, event: event)
+
+      expect(subject).to eq("Error- two matching characters: player one, player two")
+    end
   end
 
   describe "#adv" do


### PR DESCRIPTION
It was hard to always type out the long name of a character exactly.
Now, after giving the name for the first roll, a player can just type in
the start of the name and if there is a character who already matches
that name in the system, it will use that name.  If there isn't a
matching name, then it will treat the name as a new character.  If there
are two matching names already in the system, it will return an error
message, indicating that there is a duplicate match.